### PR TITLE
[Frontend] 새로고침, 수동 페이지 라우터 진입시 로그인 정보 사라짐 이슈 수정

### DIFF
--- a/frontend/src/common/styles/ThemeProvider.tsx
+++ b/frontend/src/common/styles/ThemeProvider.tsx
@@ -19,7 +19,7 @@ const themeLocalStorage = localStorageHelper<ThemeType>(THEME_STORAGE_KEY, "ligh
 
 export const CustomThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const isFirstTransition = useRef(false); // 첫 번째 테마 transition 전환 비활성화
-  const [themeType, setTheme] = useState<ThemeType>(() => localStorage.get());
+  const [themeType, setTheme] = useState<ThemeType>(() => themeLocalStorage.get());
 
   const toggleTheme = () => {
     setTheme((prevTheme) => {

--- a/frontend/src/common/styles/ThemeProvider.tsx
+++ b/frontend/src/common/styles/ThemeProvider.tsx
@@ -14,8 +14,10 @@ interface ThemeContextType {
 
 export const CustomThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const THEME_STORAGE_KEY = "theme";
+const themeLocalStorage = localStorageHelper<ThemeType>(THEME_STORAGE_KEY, "light");
+
 export const CustomThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const localStorage = localStorageHelper<ThemeType>("theme", "light");
   const isFirstTransition = useRef(false); // 첫 번째 테마 transition 전환 비활성화
   const [themeType, setTheme] = useState<ThemeType>(() => localStorage.get());
 
@@ -25,7 +27,7 @@ export const CustomThemeProvider: React.FC<PropsWithChildren> = ({ children }) =
         isFirstTransition.current = true;
       }
 
-      return localStorage.set(prevTheme === "light" ? "dark" : "light");
+      return themeLocalStorage.set(prevTheme === "light" ? "dark" : "light");
     });
   };
 

--- a/frontend/src/common/utils/localStorageHelper.ts
+++ b/frontend/src/common/utils/localStorageHelper.ts
@@ -31,7 +31,7 @@ export const localStorageHelper = <P>(key: string, init: P) => {
 
       return payload;
     },
-    get() {
+    get(): P {
       const value = localStorage.getItem(key);
 
       if (value) {

--- a/frontend/src/components/auth/AuthContext.tsx
+++ b/frontend/src/components/auth/AuthContext.tsx
@@ -64,7 +64,7 @@ export const AuthContext = createContext<ThemeContextType | undefined>(undefined
 /**
  * 로그인/회원가입 상태 관리 컨텍스트 프로바이더
  */
-export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+export const AuthFormProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialAuth);
 
   return <AuthContext.Provider value={{ state, dispatch }}>{children}</AuthContext.Provider>;

--- a/frontend/src/components/auth/AuthContext.tsx
+++ b/frontend/src/components/auth/AuthContext.tsx
@@ -1,4 +1,8 @@
-import { createContext, Dispatch, PropsWithChildren, useReducer } from "react";
+import { createContext, Dispatch, PropsWithChildren, useEffect, useMemo, useReducer } from "react";
+
+import { AuthLocalStorage, authLocalStorage, AuthLocalStorageInitial } from "./localStorage";
+import { LoginResponse } from "./api";
+import { setDefaultsHeaderAuth } from "@common/api/fetch";
 
 interface AuthState {
   email: string;
@@ -73,8 +77,13 @@ export const AuthFormProvider: React.FC<PropsWithChildren> = ({ children }) => {
 };
 
 interface AuthContextType {
-  accessToken: string;
-  userId: string;
+  login: (payload: LoginResponse, callback: CallbackFn) => void;
+  logout: (callback: CallbackFn) => void;
+}
+
+interface CallbackFn {
+  onSuccess: () => void;
+  onFailure?: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -82,9 +91,62 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 /**
  * 사용자 로그인 정보 상태 컨텍스트 프로바이더
  */
+export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const login = ({ payload }: LoginResponse, { onSuccess, onFailure }: CallbackFn) => {
+    if (saveAuthData(payload)) {
+      return onSuccess && onSuccess();
+    }
 
-// export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
-//   return (
-//     <AuthFormContext.Provider value={{ state, dispatch }}>{children}</AuthFormContext.Provider>
-//   );
-// };
+    return onFailure && onFailure();
+  };
+
+  const logout = ({ onSuccess, onFailure }: CallbackFn) => {
+    if (removeAuthData()) {
+      return onSuccess && onSuccess();
+    }
+
+    return onFailure && onFailure();
+  };
+
+  useEffect(() => {
+    saveAuthData(authLocalStorage.get());
+  }, []);
+
+  const value = useMemo(() => ({ login, logout }), []);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+/**
+ * 요청 헤더와 스토리지에 사용자 로그인 정보를 저장한다.
+ *
+ * @returns 작업이후 성공 여부에 따라 true/false를 반환.
+ */
+const saveAuthData = (data: AuthLocalStorage | undefined) => {
+  const { accessToken, userId } = data || AuthLocalStorageInitial;
+
+  if (accessToken && userId) {
+    setDefaultsHeaderAuth(accessToken);
+    authLocalStorage.set({ accessToken, userId });
+
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * 요청 헤더와 스토리지에 사용자 로그인 정보를 삭제한다.
+ *
+ * @returns 작업이후 성공 여부에 따라 true/false를 반환.
+ */
+const removeAuthData = () => {
+  try {
+    setDefaultsHeaderAuth("");
+    authLocalStorage.remove();
+
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/frontend/src/components/auth/AuthContext.tsx
+++ b/frontend/src/components/auth/AuthContext.tsx
@@ -54,18 +54,37 @@ const reducer = (state: AuthState, action: AuthAction): AuthState => {
   }
 };
 
-interface ThemeContextType {
+interface AuthFormContextType {
   state: AuthState;
   dispatch: Dispatch<AuthAction>;
 }
 
-export const AuthContext = createContext<ThemeContextType | undefined>(undefined);
+export const AuthFormContext = createContext<AuthFormContextType | undefined>(undefined);
 
 /**
- * 로그인/회원가입 상태 관리 컨텍스트 프로바이더
+ * 로그인/회원가입 폼 입력 관리 컨텍스트 프로바이더
  */
 export const AuthFormProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialAuth);
 
-  return <AuthContext.Provider value={{ state, dispatch }}>{children}</AuthContext.Provider>;
+  return (
+    <AuthFormContext.Provider value={{ state, dispatch }}>{children}</AuthFormContext.Provider>
+  );
 };
+
+interface AuthContextType {
+  accessToken: string;
+  userId: string;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+/**
+ * 사용자 로그인 정보 상태 컨텍스트 프로바이더
+ */
+
+// export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+//   return (
+//     <AuthFormContext.Provider value={{ state, dispatch }}>{children}</AuthFormContext.Provider>
+//   );
+// };

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -19,16 +19,10 @@ import { useAuth } from "./useAuth";
 import { useEffect } from "react";
 import useFetch from "@common/hooks/useFetch";
 import { requestLogin } from "./api";
-import { localStorageHelper } from "@common/utils/localStorageHelper";
 import Message from "./Message";
 import { setDefaultsHeaderAuth } from "@common/api/fetch";
 import { AuthOptionSubText } from "./Text";
-
-const LOCAL_STORAGE_KEY = "login_email";
-const defaultStorageEmail = {
-  isSave: false,
-  email: "",
-};
+import { authLocalStorage, emailLocalStorage } from "./localStorage";
 
 const Login = () => {
   return (
@@ -63,7 +57,7 @@ const Form = () => {
   const { state, dispatch } = useAuth();
 
   const loadAndDispatchEmail = () => {
-    const { email, isSave } = localStorageHelper(LOCAL_STORAGE_KEY, defaultStorageEmail).get();
+    const { email, isSave } = emailLocalStorage.get();
 
     if (isSave) {
       dispatch.email(email);
@@ -111,7 +105,7 @@ const Options = () => {
     dispatch.rememberMe(value);
 
     if (value === false) {
-      localStorageHelper(LOCAL_STORAGE_KEY, defaultStorageEmail).remove();
+      emailLocalStorage.remove();
     }
   };
 
@@ -152,7 +146,7 @@ const Submit = () => {
 
   // 체크박스 활성화된 경우 상태 저장
   const saveAndDispatchEmail = (email: string) => {
-    localStorageHelper(LOCAL_STORAGE_KEY, defaultStorageEmail).set({ email, isSave: true });
+    emailLocalStorage.set({ email, isSave: true });
   };
 
   // 로그인 요청 핸들러
@@ -167,7 +161,6 @@ const Submit = () => {
   };
 
   useEffect(() => {
-    const storage = localStorageHelper("user", { accessToken: "", userId: "" });
     const isFulfilled = !loading && data && data.payload && data.payload.accessToken;
 
     // 로그인이 성공한 시점
@@ -175,7 +168,7 @@ const Submit = () => {
       const { accessToken, userId } = data.payload;
 
       setDefaultsHeaderAuth(accessToken);
-      storage.set({ accessToken, userId });
+      authLocalStorage.set({ accessToken, userId });
       navigate("/", { replace: true });
     }
   }, [data, loading, navigate]);

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -14,7 +14,7 @@ import AuthButton from "./Button";
 import { AuthTitle, AuthSubTitle } from "./Header";
 import { AuthInput } from "./Input";
 import Checkbox from "@common/components/Checkbox";
-import { AuthProvider } from "./AuthContext";
+import { AuthFormProvider } from "./AuthContext";
 import { useAuth } from "./useAuth";
 import { useEffect } from "react";
 import useFetch from "@common/hooks/useFetch";
@@ -35,10 +35,10 @@ const Login = () => {
     <AuthPageLayout>
       <AuthFormContainer>
         <Header />
-        <AuthProvider>
+        <AuthFormProvider>
           <Form />
           <Message />
-        </AuthProvider>
+        </AuthFormProvider>
       </AuthFormContainer>
     </AuthPageLayout>
   );

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -15,14 +15,13 @@ import { AuthTitle, AuthSubTitle } from "./Header";
 import { AuthInput } from "./Input";
 import Checkbox from "@common/components/Checkbox";
 import { AuthFormProvider } from "./AuthContext";
-import { useAuth } from "./useAuth";
+import { useAuth, useAuthForm } from "./useAuth";
 import { useEffect } from "react";
 import useFetch from "@common/hooks/useFetch";
 import { requestLogin } from "./api";
 import Message from "./Message";
-import { setDefaultsHeaderAuth } from "@common/api/fetch";
 import { AuthOptionSubText } from "./Text";
-import { authLocalStorage, emailLocalStorage } from "./localStorage";
+import { emailLocalStorage } from "./localStorage";
 
 const Login = () => {
   return (
@@ -54,7 +53,7 @@ const Header = () => {
  * 사용자 입력 폼 컴포넌트
  */
 const Form = () => {
-  const { state, dispatch } = useAuth();
+  const { state, dispatch } = useAuthForm();
 
   const loadAndDispatchEmail = () => {
     const { email, isSave } = emailLocalStorage.get();
@@ -97,7 +96,7 @@ const Form = () => {
  * 회원가입 링크 컴포넌트
  */
 const Options = () => {
-  const { state, dispatch } = useAuth();
+  const { state, dispatch } = useAuthForm();
   const navigate = useNavigate();
 
   // 체크박스 핸들러
@@ -134,11 +133,12 @@ const Submit = () => {
   const {
     state: { email, password, rememberMe },
     dispatch,
-  } = useAuth();
+  } = useAuthForm();
   const {
     state: { data, loading, error },
     request,
   } = useFetch(requestLogin, { delay: 500 });
+  const { login } = useAuth();
   const navigate = useNavigate();
 
   const isReady = !(email && password) || loading;
@@ -165,13 +165,13 @@ const Submit = () => {
 
     // 로그인이 성공한 시점
     if (isFulfilled) {
-      const { accessToken, userId } = data.payload;
-
-      setDefaultsHeaderAuth(accessToken);
-      authLocalStorage.set({ accessToken, userId });
-      navigate("/", { replace: true });
+      login(data, {
+        onSuccess: () => {
+          navigate("/", { replace: true });
+        },
+      });
     }
-  }, [data, loading, navigate]);
+  }, [data, loading, login, navigate]);
 
   useEffect(() => {
     if (!error) return;

--- a/frontend/src/components/auth/Message.tsx
+++ b/frontend/src/components/auth/Message.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
-import { useAuth } from "./useAuth";
+import { useAuthForm } from "./useAuth";
 
 const AuthMessage = () => {
   const {
     state: { message },
-  } = useAuth();
+  } = useAuthForm();
 
   return <Message>{message}</Message>;
 };

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -20,7 +20,7 @@ import { requestCheckEmail, requestSignup } from "./api";
 import { AuthOptionSubText } from "./Text";
 import useFetch from "@common/hooks/useFetch";
 import { setDefaultsHeaderAuth } from "@common/api/fetch";
-import { localStorageHelper } from "@common/utils/localStorageHelper";
+import { authLocalStorage } from "./localStorage";
 
 const Signup = () => {
   return (
@@ -291,7 +291,6 @@ const Submit = () => {
   };
 
   useEffect(() => {
-    const storage = localStorageHelper("user", { accessToken: "", userId: "" });
     const isFulfilled = !loading && data && data.payload && data.payload.accessToken;
 
     // 회원가입이 성공한 시점
@@ -299,7 +298,7 @@ const Submit = () => {
       const { accessToken, userId } = data.payload;
 
       setDefaultsHeaderAuth(accessToken);
-      storage.set({ accessToken, userId });
+      authLocalStorage.set({ accessToken, userId });
       navigate("/", { replace: true });
     }
   }, [data, loading, navigate]);

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -13,7 +13,7 @@ import {
   AuthOptionsContainer as OptionsContainer,
 } from "./Layout";
 import AuthButton from "./Button";
-import { AuthProvider } from "./AuthContext";
+import { AuthFormProvider } from "./AuthContext";
 import Message from "./Message";
 import { useAuth } from "./useAuth";
 import { requestCheckEmail, requestSignup } from "./api";
@@ -27,10 +27,10 @@ const Signup = () => {
     <AuthPageLayout>
       <AuthFormContainer>
         <Header />
-        <AuthProvider>
+        <AuthFormProvider>
           <Form />
           <Message />
-        </AuthProvider>
+        </AuthFormProvider>
       </AuthFormContainer>
     </AuthPageLayout>
   );

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -15,12 +15,10 @@ import {
 import AuthButton from "./Button";
 import { AuthFormProvider } from "./AuthContext";
 import Message from "./Message";
-import { useAuth } from "./useAuth";
+import { useAuth, useAuthForm } from "./useAuth";
 import { requestCheckEmail, requestSignup } from "./api";
 import { AuthOptionSubText } from "./Text";
 import useFetch from "@common/hooks/useFetch";
-import { setDefaultsHeaderAuth } from "@common/api/fetch";
-import { authLocalStorage } from "./localStorage";
 
 const Signup = () => {
   return (
@@ -76,7 +74,7 @@ const Email = () => {
   const {
     state: { email, message },
     dispatch,
-  } = useAuth();
+  } = useAuthForm();
   const { allowEmail, isValid, emailStatus } = useEmailValidation(email, () => {
     dispatch.message("Please enter a valid email address.");
   });
@@ -180,7 +178,7 @@ const UserName = () => {
   const {
     state: { username },
     dispatch,
-  } = useAuth();
+  } = useAuthForm();
 
   return (
     <AuthInput
@@ -199,7 +197,7 @@ const Password = () => {
   const {
     state: { password, passwordConfirm },
     dispatch,
-  } = useAuth();
+  } = useAuthForm();
 
   const onChangeHandler = (value: string) => {
     const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,20}$/;
@@ -270,11 +268,12 @@ const Submit = () => {
   const {
     state: { email, password, passwordConfirm, username: name },
     dispatch,
-  } = useAuth();
+  } = useAuthForm();
   const {
     state: { data, loading, error },
     request,
   } = useFetch(requestSignup, { delay: 500 });
+  const { login } = useAuth();
   const navigate = useNavigate();
 
   const isReady = email && password && passwordConfirm && password === passwordConfirm && name;
@@ -295,13 +294,13 @@ const Submit = () => {
 
     // 회원가입이 성공한 시점
     if (isFulfilled) {
-      const { accessToken, userId } = data.payload;
-
-      setDefaultsHeaderAuth(accessToken);
-      authLocalStorage.set({ accessToken, userId });
-      navigate("/", { replace: true });
+      login(data, {
+        onSuccess: () => {
+          navigate("/", { replace: true });
+        },
+      });
     }
-  }, [data, loading, navigate]);
+  }, [data, loading, login, navigate]);
 
   useEffect(() => {
     if (!error) return;

--- a/frontend/src/components/auth/localStorage.ts
+++ b/frontend/src/components/auth/localStorage.ts
@@ -1,0 +1,30 @@
+import { localStorageHelper } from "@common/utils/localStorageHelper";
+
+const AUTH_STORAGE_KEY = "user";
+const EMAIL_STORAGE_KEY = "login_email";
+
+export interface AuthLocalStorage {
+  accessToken: string;
+  userId: string;
+}
+
+/**
+ * 사용자 인증 정보 유지 상태 스토리지
+ */
+export const authLocalStorage = localStorageHelper<AuthLocalStorage>(AUTH_STORAGE_KEY, {
+  accessToken: "",
+  userId: "",
+});
+
+export interface EmailLocalStorage {
+  isSave: boolean;
+  email: string;
+}
+
+/**
+ * 사용자 입력 이메일 유지 상태 스토리지
+ */
+export const emailLocalStorage = localStorageHelper<EmailLocalStorage>(EMAIL_STORAGE_KEY, {
+  isSave: false,
+  email: "",
+});

--- a/frontend/src/components/auth/localStorage.ts
+++ b/frontend/src/components/auth/localStorage.ts
@@ -8,15 +8,20 @@ export interface AuthLocalStorage {
   userId: string;
 }
 
+export const AuthLocalStorageInitial: AuthLocalStorage = {
+  accessToken: "",
+  userId: "",
+};
+
 /**
  * 사용자 인증 정보 유지 상태 스토리지
  */
-export const authLocalStorage = localStorageHelper<AuthLocalStorage>(AUTH_STORAGE_KEY, {
-  accessToken: "",
-  userId: "",
-});
+export const authLocalStorage = localStorageHelper<AuthLocalStorage>(
+  AUTH_STORAGE_KEY,
+  AuthLocalStorageInitial
+);
 
-export interface EmailLocalStorage {
+interface EmailLocalStorage {
   isSave: boolean;
   email: string;
 }

--- a/frontend/src/components/auth/useAuth.ts
+++ b/frontend/src/components/auth/useAuth.ts
@@ -1,11 +1,14 @@
 import { useContext } from "react";
-import { AuthFormContext } from "./AuthContext";
+import { AuthContext, AuthFormContext } from "./AuthContext";
 
-export const useAuth = () => {
+/**
+ * 로그인/회원가입 폼 양식 상태 괸리 훅
+ */
+export const useAuthForm = () => {
   const context = useContext(AuthFormContext);
 
   if (!context) {
-    throw new Error("useAuth must be used within a AuthProvider");
+    throw new Error("useAuthForm must be used within a AuthFormProvider");
   }
 
   const dispatch = {
@@ -30,4 +33,21 @@ export const useAuth = () => {
   };
 
   return { state: context.state, dispatch };
+};
+
+/**
+ * 로그인 상태 관리 훅
+ *
+ * `login` - 함수를 호출하면 로그인 정보를 브라우저에 저장합니다.
+ *
+ * `logout` - 함수를 호출하면 로그인 정보를 브라우저에서 삭제합니다.
+ */
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used within a AuthProvider");
+  }
+
+  return context;
 };

--- a/frontend/src/components/auth/useAuth.ts
+++ b/frontend/src/components/auth/useAuth.ts
@@ -1,8 +1,8 @@
 import { useContext } from "react";
-import { AuthContext } from "./AuthContext";
+import { AuthFormContext } from "./AuthContext";
 
 export const useAuth = () => {
-  const context = useContext(AuthContext);
+  const context = useContext(AuthFormContext);
 
   if (!context) {
     throw new Error("useAuth must be used within a AuthProvider");

--- a/frontend/src/components/myPage/userApi.ts
+++ b/frontend/src/components/myPage/userApi.ts
@@ -1,3 +1,4 @@
+import { authLocalStorage } from "@components/auth/localStorage";
 import axios from "axios";
 
 // 비밀번호 변경 API
@@ -5,9 +6,9 @@ export const changePassword = async (
   oldPassword: string,
   newPassword: string
 ): Promise<boolean> => {
-  const token = localStorage.getItem("token"); // 로컬 스토리지에서 JWT 토큰 가져오기
+  const { accessToken } = authLocalStorage.get(); // 로컬 스토리지에서 JWT 토큰 가져오기
 
-  if (!token) {
+  if (!accessToken) {
     throw new Error("토큰이 존재하지 않습니다."); // 토큰이 없을 경우 오류 처리
   }
 
@@ -20,7 +21,7 @@ export const changePassword = async (
       },
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       }
     );
@@ -33,16 +34,16 @@ export const changePassword = async (
 
 // 회원 탈퇴 API
 export const deleteUser = async (): Promise<boolean> => {
-  const token = localStorage.getItem("token");
+  const { accessToken } = authLocalStorage.get(); // 로컬 스토리지에서 JWT 토큰 가져오기
 
-  if (!token) {
+  if (!accessToken) {
     throw new Error("토큰이 존재하지 않습니다.");
   }
 
   try {
     const response = await axios.delete("/users/me", {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "react-router-dom";
 
 import router from "@routes/router";
 import { CustomThemeProvider } from "@common/styles/ThemeProvider";
+import { AuthProvider } from "@components/auth/AuthContext.tsx";
 
 const enableMocking = async () => {
   if (process.env.NODE_ENV !== "development" || import.meta.env.VITE_MSW_ENABLED !== "true") {
@@ -21,7 +22,9 @@ enableMocking().then(() => {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <CustomThemeProvider>
-        <RouterProvider router={router} />
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
       </CustomThemeProvider>
     </StrictMode>
   );


### PR DESCRIPTION
## 🧃 Pull Request

### 🍉 코멘트

<!-- 해당 커밋이 어떤 작업을 했는지 간단하게 작성해주세요. -->

- 새로고침, 수동 페이지 라우터 진입시 auth 헤더 사라짐 이슈 수정
- `localStorageHelper` 유틸함수를 사용하여 쉽게 `localStorage API`에 접근이 가능하도록 하였습니다.

### 🪿 연관된 이슈

<!-- 이슈 참조를 걸어주세요. -->

- #32 

### ✅ PR 포인트 & 궁금한 점

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- 이제 로그인, 회원가입이 프로세스가 진행되면 토큰 헤더 정보를 포함하지 않고 API 요청을 시도해도 문제없이 동작합니다.
- `useAuth` 훅을 통해서 사용자 로그인, 로그아웃에 대한 로직을 쉽게 사용 가능하게 만들었습니다.
```ts
const { login } = useAuth();
...

// `login`함수를 호출하여 성공적으로 내부 작업(헤더 설정, 스토리지 설정)이 완료되면 onSuccess에 전달한 콜백 함수가 실행됩니다.
if (isFulfilled) {
  login(data, {
    onSuccess: () => {
      navigate("/", { replace: true });
    },
  });
}
```

<!-- 리뷰어 할당 안내 -->
<!-- 리뷰어는 꼭 1명 이상 지정해주세요! -->