### PR TITLE
[Feat] 설정페이지 배너 수정 기능

### DIFF
--- a/backend/src/controller/userController.ts
+++ b/backend/src/controller/userController.ts
@@ -233,6 +233,38 @@ export class UserController {
       return res.status(500).json(createErrorResponse(500, `${error}`));
     }
   }
+  //배너 이미지 변경
+  async updateBanner(req: Request, res: Response) {
+    try {
+      const { bannerImage } = req.body;
+      const userId = req.user?.userId;
+
+      if (!userId) {
+        return res.status(400).json(createErrorResponse(400, "User ID is required"));
+      }
+      const user = await this.userService.getUserById(userId);
+
+      if (!user) {
+        return res.status(404).json(createErrorResponse(404, "User not found"));
+      }
+      const updateData: UserSchemaType = {
+        name: user.name || "",
+        email: user.email || "",
+        description: user.description || "",
+        password: user.password || "",
+        bannerImage: bannerImage,
+      };
+
+      await this.userService.updateUser(userId, updateData);
+
+      return res.status(200).json({
+        statusCode: 200,
+        payload: { isChange: true },
+      });
+    } catch (error) {
+      return res.status(500).json(createErrorResponse(500, `${error}`));
+    }
+  }
   //비밀번호 변경
   async updatePw(req: Request, res: Response) {
     try {

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -13,6 +13,7 @@ route.get("/me", userController.readMine.bind(userController));
 route.patch("/password", userController.updatePw.bind(userController));
 route.patch("/profile", userController.updateProfile.bind(userController));
 route.patch("/name", userController.updateName.bind(userController));
+route.patch("/banner", userController.updateBanner.bind(userController));
 route.delete("/me", userController.delete.bind(userController));
 
 export default route;

--- a/frontend/src/components/main/Banner.tsx
+++ b/frontend/src/components/main/Banner.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { fetchBannerImage } from "./bannerApi";
+import { useBannerModal } from "@components/myPage/BannerModalContext";
 
 const DEFAULT_BANNER_IMAGE = "/default-banner-image.png"; // 기본 배너 이미지 경로
 
 const Banner: React.FC = () => {
   const [bannerImage, setBannerImage] = useState<string | null>(null);
+  const { isBannerModalOpen } = useBannerModal();
 
   // 배너 이미지 API 호출 및 설정
   useEffect(() => {
@@ -20,7 +22,7 @@ const Banner: React.FC = () => {
     };
 
     getBannerImage();
-  }, []);
+  }, [isBannerModalOpen]);
 
   return <StyledBanner src={bannerImage || DEFAULT_BANNER_IMAGE} alt="Banner Image" />;
 };

--- a/frontend/src/components/main/bannerApi.ts
+++ b/frontend/src/components/main/bannerApi.ts
@@ -5,7 +5,8 @@ export interface User {
 }
 
 export const fetchBannerImage = async (): Promise<string | null> => {
-  const response = await httpClient.get<User>("/users/me");
+  const URL = "users/me";
+  const { data } = await httpClient.get<{ payload: User }>(URL);
 
-  return response.data.bannerImage;
+  return data.payload.bannerImage;
 };

--- a/frontend/src/components/myPage/BannerModalContext.tsx
+++ b/frontend/src/components/myPage/BannerModalContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+// Context의 상태 타입 정의
+interface BannerModalContextType {
+  isBannerModalOpen: boolean;
+  setBannerModalOpen: (open: boolean) => void;
+}
+
+// Context 생성
+const BannerModalContext = createContext<BannerModalContextType>({
+  isBannerModalOpen: false,
+  setBannerModalOpen: () => {},
+});
+
+// Provider 컴포넌트
+export const BannerModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [isBannerModalOpen, setBannerModalOpen] = useState<boolean>(false);
+
+  return (
+    <BannerModalContext.Provider value={{ isBannerModalOpen, setBannerModalOpen }}>
+      {children}
+    </BannerModalContext.Provider>
+  );
+};
+
+// Context를 사용하는 훅
+export const useBannerModal = (): BannerModalContextType => {
+  return useContext(BannerModalContext);
+};

--- a/frontend/src/components/myPage/ChangePw.tsx
+++ b/frontend/src/components/myPage/ChangePw.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { changePassword } from "./userApi"; // changePassword API 함수 임포트
+import { changePassword } from "./api/userApi"; // changePassword API 함수 임포트
 
 interface ChangePwProps {
   setStatus: React.Dispatch<React.SetStateAction<boolean>>;

--- a/frontend/src/components/myPage/SettingPage.tsx
+++ b/frontend/src/components/myPage/SettingPage.tsx
@@ -9,12 +9,13 @@ import { useNavigate } from "react-router-dom";
 import NameEditModal from "./modals/NameEditModal";
 import ProfileEditModal from "./modals/ProfileEditModal";
 import BannerEditModal from "./modals/BannerEditModal";
+import { useBannerModal } from "./BannerModalContext";
 const DEFAULT_PROFILE_IMAGE = "/default-profile-image.png";
 const SettingPage = () => {
   const [user, setUser] = useState<User | null>(null);
   const [status, setStatus] = useState<boolean>(false);
   const [isImageModalOpen, setImageModalOpen] = useState(false);
-  const [isBannerModalOpen, setBannerModalOpen] = useState(false);
+  const { isBannerModalOpen, setBannerModalOpen } = useBannerModal();
   const [isNameModalOpen, setNameModalOpen] = useState(false);
 
   const navigate = useNavigate();
@@ -28,6 +29,7 @@ const SettingPage = () => {
 
     fetchUser();
   }, [isImageModalOpen, isNameModalOpen, isBannerModalOpen]);
+
   const changePw = () => {
     setStatus(true);
   };

--- a/frontend/src/components/myPage/SettingPage.tsx
+++ b/frontend/src/components/myPage/SettingPage.tsx
@@ -81,9 +81,11 @@ const SettingPage = () => {
 
   return (
     <>
-      <ImgEditBtn onClick={editBanner}>
-        <img src={edit} />
-      </ImgEditBtn>
+      <BtnWrapper>
+        <BannerEditBtn onClick={editBanner}>
+          <img src={edit} />
+        </BannerEditBtn>
+      </BtnWrapper>
       {status ? (
         <ChangePw setStatus={setStatus} /> // status가 true이면 ChangePw 컴포넌트 렌더링
       ) : (
@@ -136,7 +138,10 @@ const SettingPage = () => {
     </>
   );
 };
-
+const BtnWrapper = styled.div`
+  margin-top: -25px;
+  margin-right: -16px;
+`;
 const Wrapper = styled.div`
   display: flex;
   justify-content: center;
@@ -185,6 +190,13 @@ const UserName = styled.p`
   align-items: center;
 `;
 
+const BannerEditBtn = styled.button`
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-left: 98%;
+  padding-top: 10px;
+`;
 const NameEditBtn = styled.button`
   background-color: transparent;
   border: none;

--- a/frontend/src/components/myPage/SettingPage.tsx
+++ b/frontend/src/components/myPage/SettingPage.tsx
@@ -1,18 +1,20 @@
 import styled from "styled-components";
 import edit from "@assets/icons/edit.svg";
-import { deleteUser, getUser } from "./userApi";
+import { deleteUser, getUser } from "./api/userApi";
 import { useEffect, useState } from "react";
-import { User } from "./userApi";
+import { User } from "./api/userApi";
 import ChangePw from "./ChangePw";
 import { useAuth } from "@components/auth/useAuth";
 import { useNavigate } from "react-router-dom";
-import NameEditModal from "./NameEditModal";
-import ProfileEditModal from "./ProfileEditModal";
+import NameEditModal from "./modals/NameEditModal";
+import ProfileEditModal from "./modals/ProfileEditModal";
+import BannerEditModal from "./modals/BannerEditModal";
 const DEFAULT_PROFILE_IMAGE = "/default-profile-image.png";
 const SettingPage = () => {
   const [user, setUser] = useState<User | null>(null);
   const [status, setStatus] = useState<boolean>(false);
   const [isImageModalOpen, setImageModalOpen] = useState(false);
+  const [isBannerModalOpen, setBannerModalOpen] = useState(false);
   const [isNameModalOpen, setNameModalOpen] = useState(false);
 
   const navigate = useNavigate();
@@ -25,7 +27,7 @@ const SettingPage = () => {
     };
 
     fetchUser();
-  }, [isImageModalOpen, isNameModalOpen]);
+  }, [isImageModalOpen, isNameModalOpen, isBannerModalOpen]);
   const changePw = () => {
     setStatus(true);
   };
@@ -48,11 +50,14 @@ const SettingPage = () => {
     }
   };
   const editImg = () => {
-    setImageModalOpen(true); // 이미지 모달 열기
+    setImageModalOpen(true); // 프로필 이미지 모달 열기
   };
 
   const editName = () => {
     setNameModalOpen(true); // 이름 모달 열기
+  };
+  const editBanner = () => {
+    setBannerModalOpen(true); // 배너 이미지 모달 열기
   };
   const { logout } = useAuth();
 
@@ -74,6 +79,9 @@ const SettingPage = () => {
 
   return (
     <>
+      <ImgEditBtn onClick={editBanner}>
+        <img src={edit} />
+      </ImgEditBtn>
       {status ? (
         <ChangePw setStatus={setStatus} /> // status가 true이면 ChangePw 컴포넌트 렌더링
       ) : (
@@ -100,7 +108,20 @@ const SettingPage = () => {
               <Button onClick={handleLogout}>로그아웃</Button>
             </UserProfile>
           </ProfileWrapper>
-          {isImageModalOpen && <ProfileEditModal onClose={() => setImageModalOpen(false)} />}
+          {isBannerModalOpen && (
+            <BannerEditModal
+              onClose={() => {
+                setBannerModalOpen(false);
+              }}
+            />
+          )}
+          {isImageModalOpen && (
+            <ProfileEditModal
+              onClose={() => {
+                setImageModalOpen(false);
+              }}
+            />
+          )}
           {isNameModalOpen && (
             <NameEditModal
               onClose={() => {

--- a/frontend/src/components/myPage/api/userApi.ts
+++ b/frontend/src/components/myPage/api/userApi.ts
@@ -13,6 +13,9 @@ interface PasswordForm {
 interface ProfileForm {
   profileImage: string;
 }
+interface BannerForm {
+  bannerImage: string;
+}
 interface NameForm {
   name: string;
 }
@@ -45,6 +48,19 @@ export const changePassword = async (payload: PasswordForm): Promise<boolean> =>
 export const changeProfile = async (payload: ProfileForm): Promise<boolean> => {
   try {
     const URL = `/users/profile`;
+
+    const { data } = await httpClient.patch(URL, payload);
+
+    return data.payload.isChange;
+  } catch {
+    return false;
+  }
+};
+
+//배너 이미지 변경 API
+export const changeBanner = async (payload: BannerForm): Promise<boolean> => {
+  try {
+    const URL = `/users/banner`;
 
     const { data } = await httpClient.patch(URL, payload);
 

--- a/frontend/src/components/myPage/modals/BannerEditModal.tsx
+++ b/frontend/src/components/myPage/modals/BannerEditModal.tsx
@@ -1,43 +1,43 @@
 import styled from "styled-components";
-import { changeProfile } from "./userApi";
+import { changeBanner } from "../api/userApi";
 import { useState } from "react";
 
 const closeBtn = "/closeBtn.png";
-const DEFAULT_PROFILE_IMAGE = "/default-profile-image.png";
+const DEFAULT_PROFILE_IMAGE = "/default-banner-image.png";
 
 interface ImageEditModalProps {
   onClose: () => void;
 }
 
-//프로필 이미지 수정 모달
+//배너 이미지 수정 모달
 const ProfileEditModal: React.FC<ImageEditModalProps> = ({ onClose }) => {
   const isValidImageUrl = (url: string) => {
     return /^https?:\/\//i.test(url);
   };
 
-  const [profileImage, setNewImg] = useState("");
+  const [bannerImage, setNewImg] = useState("");
   const handleConfirm = async () => {
-    if (!isValidImageUrl(profileImage)) {
+    if (!isValidImageUrl(bannerImage)) {
       alert("유효하지 않은 이미지 형식입니다.");
     } else {
-      const isChangeSuccessful = await changeProfile({ profileImage });
+      const isChangeSuccessful = await changeBanner({ bannerImage });
 
       if (isChangeSuccessful) {
-        alert("프로필 이미지가 변경되었습니다.");
+        alert("배너 이미지가 변경되었습니다.");
         onClose();
       } else {
-        alert("프로필 이미지 변경에 실패했습니다.");
+        alert("배너 이미지 변경에 실패했습니다.");
       }
     }
   };
   const handleDefault = async () => {
-    const isChangeSuccessful = await changeProfile({ profileImage: DEFAULT_PROFILE_IMAGE });
+    const isChangeSuccessful = await changeBanner({ bannerImage: DEFAULT_PROFILE_IMAGE });
 
     if (isChangeSuccessful) {
-      alert("프로필 이미지가 변경되었습니다.");
+      alert("배너 이미지가 변경되었습니다.");
       onClose();
     } else {
-      alert("프로필 이미지 변경에 실패했습니다.");
+      alert("배너 이미지 변경에 실패했습니다.");
     }
   };
 
@@ -46,14 +46,14 @@ const ProfileEditModal: React.FC<ImageEditModalProps> = ({ onClose }) => {
       <ModalOverlay>
         <ModalContent>
           <Header>
-            <h3>프로필 이미지 변경</h3>
+            <h3>배너 이미지 변경</h3>
             <CloseButton onClick={onClose}>
               <img src={closeBtn} width="30px" />
             </CloseButton>
           </Header>
           <Input
             type="text"
-            value={profileImage}
+            value={bannerImage}
             onChange={(e) => setNewImg(e.target.value.trim())}
           />
 

--- a/frontend/src/components/myPage/modals/NameEditModal.tsx
+++ b/frontend/src/components/myPage/modals/NameEditModal.tsx
@@ -1,0 +1,108 @@
+import styled from "styled-components";
+import { changeName } from "../api/userApi";
+import { useState } from "react";
+
+const closeBtn = "/closeBtn.png";
+
+interface NameEditModalProps {
+  onClose: () => void;
+}
+const NameEditModal: React.FC<NameEditModalProps> = ({ onClose }) => {
+  const [name, setNewName] = useState("");
+  const handleConfirm = async () => {
+    const isChangeSuccessful = await changeName({ name });
+
+    if (isChangeSuccessful) {
+      alert("이름이 변경되었습니다.");
+      onClose();
+    } else {
+      alert("이름 변경에 실패했습니다.");
+    }
+  };
+
+  return (
+    <>
+      {" "}
+      <ModalOverlay>
+        <ModalContent>
+          <Header>
+            <h3>이름 변경</h3>
+            <CloseButton onClick={onClose}>
+              <img src={closeBtn} width="30px" />
+            </CloseButton>
+          </Header>
+          <Input type="text" value={name} onChange={(e) => setNewName(e.target.value.trim())} />
+          <ButtonWrapper>
+            <Button onClick={handleConfirm}>변경</Button>
+            <Button onClick={onClose}>닫기</Button>
+          </ButtonWrapper>
+        </ModalContent>
+      </ModalOverlay>
+    </>
+  );
+};
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 5;
+`;
+
+const ModalContent = styled.div`
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  width: 300px;
+  max-width: 90%;
+  text-align: center;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 10px;
+  margin-top: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  font-size: 1rem;
+  box-sizing: border-box;
+`;
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+`;
+const Button = styled.button`
+  padding: 3px 10px;
+  border: 0.5px solid #ddd;
+  border-radius: 5px;
+  background-color: white;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+`;
+
+export default NameEditModal;

--- a/frontend/src/components/myPage/modals/ProfileEditModal.tsx
+++ b/frontend/src/components/myPage/modals/ProfileEditModal.tsx
@@ -1,47 +1,71 @@
 import styled from "styled-components";
-import { changeName } from "./userApi";
+import { changeProfile } from "../api/userApi";
 import { useState } from "react";
 
 const closeBtn = "/closeBtn.png";
+const DEFAULT_PROFILE_IMAGE = "/default-profile-image.png";
 
-interface NameEditModalProps {
+interface ImageEditModalProps {
   onClose: () => void;
 }
-const NameEditModal: React.FC<NameEditModalProps> = ({ onClose }) => {
-  const [name, setNewName] = useState("");
+
+//프로필 이미지 수정 모달
+const ProfileEditModal: React.FC<ImageEditModalProps> = ({ onClose }) => {
+  const isValidImageUrl = (url: string) => {
+    return /^https?:\/\//i.test(url);
+  };
+
+  const [profileImage, setNewImg] = useState("");
   const handleConfirm = async () => {
-    const isChangeSuccessful = await changeName({ name });
+    if (!isValidImageUrl(profileImage)) {
+      alert("유효하지 않은 이미지 형식입니다.");
+    } else {
+      const isChangeSuccessful = await changeProfile({ profileImage });
+
+      if (isChangeSuccessful) {
+        alert("프로필 이미지가 변경되었습니다.");
+        onClose();
+      } else {
+        alert("프로필 이미지 변경에 실패했습니다.");
+      }
+    }
+  };
+  const handleDefault = async () => {
+    const isChangeSuccessful = await changeProfile({ profileImage: DEFAULT_PROFILE_IMAGE });
 
     if (isChangeSuccessful) {
-      alert("이름이 변경되었습니다.");
+      alert("프로필 이미지가 변경되었습니다.");
       onClose();
     } else {
-      alert("이름 변경에 실패했습니다.");
+      alert("프로필 이미지 변경에 실패했습니다.");
     }
   };
 
   return (
     <>
-      {" "}
       <ModalOverlay>
         <ModalContent>
           <Header>
-            <h3>이름 변경</h3>
+            <h3>프로필 이미지 변경</h3>
             <CloseButton onClick={onClose}>
               <img src={closeBtn} width="30px" />
             </CloseButton>
           </Header>
-          <Input type="text" value={name} onChange={(e) => setNewName(e.target.value.trim())} />
+          <Input
+            type="text"
+            value={profileImage}
+            onChange={(e) => setNewImg(e.target.value.trim())}
+          />
+
           <ButtonWrapper>
             <Button onClick={handleConfirm}>변경</Button>
-            <Button onClick={onClose}>닫기</Button>
+            <Button onClick={handleDefault}>삭제</Button>
           </ButtonWrapper>
         </ModalContent>
       </ModalOverlay>
     </>
   );
 };
-
 const ModalOverlay = styled.div`
   position: fixed;
   top: 0;
@@ -64,7 +88,6 @@ const ModalContent = styled.div`
   text-align: center;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 `;
-
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
@@ -78,7 +101,6 @@ const CloseButton = styled.button`
   cursor: pointer;
   padding: 0;
 `;
-
 const Input = styled.input`
   width: 100%;
   padding: 10px;
@@ -105,4 +127,4 @@ const Button = styled.button`
   }
 `;
 
-export default NameEditModal;
+export default ProfileEditModal;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from "react-router-dom";
 import router from "@routes/router";
 import { CustomThemeProvider } from "@common/styles/ThemeProvider";
 import { AuthProvider } from "@components/auth/AuthContext.tsx";
+import { BannerModalProvider } from "@components/myPage/BannerModalContext.tsx";
 
 const enableMocking = async () => {
   if (process.env.NODE_ENV !== "development" || import.meta.env.VITE_MSW_ENABLED !== "true") {
@@ -23,7 +24,9 @@ enableMocking().then(() => {
     <StrictMode>
       <CustomThemeProvider>
         <AuthProvider>
-          <RouterProvider router={router} />
+          <BannerModalProvider>
+            <RouterProvider router={router} />
+          </BannerModalProvider>
         </AuthProvider>
       </CustomThemeProvider>
     </StrictMode>


### PR DESCRIPTION
## 🧃 Pull Request

### 🍉 코멘트

<!-- 해당 커밋이 어떤 작업을 했는지 간단하게 작성해주세요. -->

- 배너 수정 api 설계했습니다 (PATCH users/banner)
- 설정페이지에서 배너 수정 모달 설계했습니다.
- 파일 경로 일부 수정하였습니다.

### 🪿 연관된 이슈

<!-- 이슈 참조를 걸어주세요. -->

- #43 

### ✅ PR 포인트 & 궁금한 점

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- context 사용으로 인해 main.tsx와 banner.ts에 일부 코드를 수정하였습니다.
- bannerApi부분 코드 일부 수정하였습니다.
- 배너 이미지 수정에서도 프로필 이미지 수정과 마찬가지로 변경과 삭제(기본 이미지로 변경) 기능이 있습니다.
- 사실상 더 이상의 기능추가는 없을것 같아서, backend에서 레이어 세분화 작업과 css 수정 정도의 작업을 생각중입니다. 이에 따른 좋은 아이디어 있으시면 말씀 부탁드립니다. 
- modal 파일들과 api 파일에 구분이 안가서 modal 폴더와 api 폴더를 만들어서 일부 구조가 수정되었는데 폴더컨벤션에 어긋난다면 다시 원래대로 수정하겠습니다..! 

<!-- 리뷰어 할당 안내 -->
<!-- 리뷰어는 꼭 1명 이상 지정해주세요! -->
